### PR TITLE
Fix Readme Page Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🦀 Rust LLM from Scratch
 
-[![Rust](https://github.com/mrityunjai01/RustGPT/actions/workflows/rust.yml/badge.svg)](https://github.com/mrityunjai01/RustGPT/actions/workflows/rust.yml)
+[![Rust](https://github.com/tekaratzas/RustGPT/actions/workflows/rust.yml/badge.svg)](https://github.com/tekaratzas/RustGPT/actions/workflows/rust.yml)
 
 https://github.com/user-attachments/assets/ec4a4100-b03a-4b3c-a7d6-806ea54ed4ed
 


### PR DESCRIPTION
The badge was using the workflow status of a fork of the repo.