### PR TITLE
Feature/count total parameters

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -134,4 +134,8 @@ impl Layer for Embeddings {
         // Return gradient to propagate further back
         grads.to_owned()
     }
+
+    fn parameters(&self) -> usize {
+        self.token_embeddings.len() + self.positional_embeddings.len()
+    }
 }

--- a/src/feed_forward.rs
+++ b/src/feed_forward.rs
@@ -107,4 +107,8 @@ impl Layer for FeedForward {
 
         output + input // residual connection (no LayerNorm here)
     }
+
+    fn parameters(&self) -> usize {
+        self.b1.len() + self.b2.len() + self.w1.len() + self.w2.len()
+    }
 }

--- a/src/layer_norm.rs
+++ b/src/layer_norm.rs
@@ -1,4 +1,4 @@
-use crate::adam::Adam;
+use crate::{adam::Adam};
 use crate::llm::Layer;
 use ndarray::{Array2, Axis};
 
@@ -91,5 +91,9 @@ impl Layer for LayerNorm {
         self.optimizer_beta.step(&mut self.beta, &grad_beta, lr);
 
         grad_input
+    }
+
+    fn parameters(&self) -> usize {
+        self.gamma.len() + self.beta.len()
     }
 }

--- a/src/layer_norm.rs
+++ b/src/layer_norm.rs
@@ -1,4 +1,4 @@
-use crate::{adam::Adam};
+use crate::adam::Adam;
 use crate::llm::Layer;
 use ndarray::{Array2, Axis};
 

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -69,26 +69,25 @@ impl LLM {
     }
 
     pub fn total_parameters(&self) -> usize {
-
-        // Calculate parameters based on model architecture
-        let vocab_size = self.vocab.words.len();
-        let layer_norm_learnable_parameters = 2; // gamma, beta.
-        let attention_distinct_matrices = 3; // w_q, w_k, w_v
-        let transformer_block_type = "TransformerBlock";
+        // Define Constants
+        const LAYER_NORM_LEARNABLE_PARAMETERS: usize = 2; // gamma, beta.
+        const ATTENTION_DISTINCT_MATRICES: usize = 3; // w_q, w_k, w_v
+        const TRANSFORMER_BLOCK_TYPE: &str = "TransformerBlock";
         
         // Embeddings parameters
+        let vocab_size: usize = self.vocab.words.len();
         let token_emb_params = vocab_size * EMBEDDING_DIM;
         let pos_emb_params = MAX_SEQ_LEN * EMBEDDING_DIM;
         
         // Count transformer blocks by checking layer types
         let transformer_blocks: usize = self.network
             .iter()
-            .filter(|layer| layer.layer_type() == transformer_block_type)
+            .filter(|layer| layer.layer_type() == TRANSFORMER_BLOCK_TYPE)
             .count();
         
         // Per transformer block parameters (number of parameters in each layer)
-        let layernorm_params = layer_norm_learnable_parameters * EMBEDDING_DIM; // gamma, beta
-        let attention_params = attention_distinct_matrices * EMBEDDING_DIM * EMBEDDING_DIM;
+        let layernorm_params = LAYER_NORM_LEARNABLE_PARAMETERS * EMBEDDING_DIM; // gamma, beta
+        let attention_params = ATTENTION_DISTINCT_MATRICES * EMBEDDING_DIM * EMBEDDING_DIM;
         let feedforward_params = EMBEDDING_DIM * HIDDEN_DIM + HIDDEN_DIM + HIDDEN_DIM * EMBEDDING_DIM + EMBEDDING_DIM; // w1, b1, w2, b2
         
         // each block has 2 layer norms, attention, and feedforward: 

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -57,7 +57,7 @@ impl LLM {
         // Sum the parameters across all layers in the network
         self.network
             .iter()
-            .map(|layer: &Box<dyn Layer> | layer.parameters())
+            .map(|layer: &Box<dyn Layer>| layer.parameters())
             .sum::<usize>()
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,8 @@ fn main() {
         MAX_SEQ_LEN, EMBEDDING_DIM, HIDDEN_DIM
     );
 
+    println!("Total parameters: {}", llm.total_parameters());
+
     println!("\n=== BEFORE TRAINING ===");
     println!("Input: {}", string);
     println!("Output: {}", llm.predict(&string));

--- a/src/output_projection.rs
+++ b/src/output_projection.rs
@@ -52,4 +52,8 @@ impl Layer for OutputProjection {
 
         grad_input
     }
+
+    fn parameters(&self) -> usize {
+        self.w_out.len() + self.b_out.len()
+    }
 }

--- a/src/self_attention.rs
+++ b/src/self_attention.rs
@@ -182,4 +182,8 @@ impl Layer for SelfAttention {
 
         grad_input
     }
+
+    fn parameters(&self) -> usize {
+        self.w_k.len() + self.w_q.len() + self.w_v.len()
+    }
 }

--- a/src/transformer.rs
+++ b/src/transformer.rs
@@ -54,6 +54,9 @@ impl Layer for TransformerBlock {
     }
 
     fn parameters(&self) -> usize {
-        self.attention.parameters() + self.feed_forward.parameters() + self.norm1.parameters() + self.norm2.parameters()
+        self.attention.parameters()
+            + self.feed_forward.parameters()
+            + self.norm1.parameters()
+            + self.norm2.parameters()
     }
 }

--- a/src/transformer.rs
+++ b/src/transformer.rs
@@ -52,4 +52,8 @@ impl Layer for TransformerBlock {
 
         grad_attn
     }
+
+    fn parameters(&self) -> usize {
+        self.attention.parameters() + self.feed_forward.parameters() + self.norm1.parameters() + self.norm2.parameters()
+    }
 }

--- a/tests/llm_test.rs
+++ b/tests/llm_test.rs
@@ -48,6 +48,11 @@ impl Layer for TestOutputProjectionLayer {
 
         return grad_input;
     }
+
+    fn parameters(&self) -> usize {
+        const NUM_PARAMETERS_TEST_LAYER: usize = 0;
+        NUM_PARAMETERS_TEST_LAYER
+    }
 }
 
 impl TestOutputProjectionLayer {

--- a/tests/llm_test.rs
+++ b/tests/llm_test.rs
@@ -163,6 +163,5 @@ fn test_llm_total_parameters() {
     (2 * EMBEDDING_DIM) + // LayerNorm
     (EMBEDDING_DIM * HIDDEN_DIM + HIDDEN_DIM + HIDDEN_DIM * EMBEDDING_DIM + EMBEDDING_DIM); // FeedForward
     let expected_output_projection_parameters = EMBEDDING_DIM * vocab_size + vocab_size;
-    assert!(param_count == expected_embeddings_parameters + 
-        expected_transformer_block_parameters + expected_output_projection_parameters);
+    assert!(param_count == expected_embeddings_parameters + expected_transformer_block_parameters + expected_output_projection_parameters);
 }

--- a/tests/llm_test.rs
+++ b/tests/llm_test.rs
@@ -1,6 +1,9 @@
+use llm::transformer::TransformerBlock;
 use llm::EMBEDDING_DIM;
 use llm::Embeddings;
 use llm::output_projection::OutputProjection;
+use llm::HIDDEN_DIM;
+use llm::MAX_SEQ_LEN;
 use llm::{LLM, Layer, Vocab};
 use ndarray::Array2;
 
@@ -129,4 +132,32 @@ fn test_llm_integration() {
 
     let input_text = "hello world this is rust";
     llm.train(vec![input_text], 10, 0.01);
+}
+
+#[test]
+fn test_llm_total_parameters() {
+    let vocab = Vocab::default();
+    let vocab_size = vocab.encode.len();
+    
+    // Create an LLM with actual layers to get a meaningful parameter count
+    let embeddings = Box::new(Embeddings::new(vocab.clone()));
+    let transformer_block = Box::new(TransformerBlock::new(EMBEDDING_DIM, HIDDEN_DIM));
+    let output_projection = Box::new(OutputProjection::new(EMBEDDING_DIM, vocab_size));
+    
+    let llm = LLM::new(vocab.clone(), vec![embeddings, transformer_block, output_projection]);
+    
+    // The total parameters should be greater than 0 for a model with actual layers
+    let param_count = llm.total_parameters();
+    assert!(param_count > 0);
+
+    // Let's validate that this is equal to the expected total number of parameters. (based on our source)
+    let expected_embeddings_parameters = vocab_size * EMBEDDING_DIM + MAX_SEQ_LEN * EMBEDDING_DIM;
+    let expected_transformer_block_parameters = 
+    (2 * EMBEDDING_DIM) + // LayerNorm
+    (3 * EMBEDDING_DIM * EMBEDDING_DIM) + // SelfAttention
+    (2 * EMBEDDING_DIM) + // LayerNorm
+    (EMBEDDING_DIM * HIDDEN_DIM + HIDDEN_DIM + HIDDEN_DIM * EMBEDDING_DIM + EMBEDDING_DIM); // FeedForward
+    let expected_output_projection_parameters = EMBEDDING_DIM * vocab_size + vocab_size;
+    assert!(param_count == expected_embeddings_parameters + 
+        expected_transformer_block_parameters + expected_output_projection_parameters);
 }


### PR DESCRIPTION
Added a count total parameters method to LLM. 

The methodology for the calculation was based off the following blog article by Michael Wornow: [Transformer Math (Part 1) - Counting Model Parameters](https://michaelwornow.net/2024/01/18/counting-params-in-transformer?utm_source=chatgpt.com).

This was a great article which back-solved the number of parameters for Hugging Face's GPT2 Model. I was able to leverage the majority of this proof (with minor adjustments required), in this method.